### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@
 If you prefer to do it manually with the cleaner git history
 
 ```bash
+# [optional] if you are using Windows, you need to close the end-of-line conversion
+git config --global core.autocrlf input
+
 # clone repository
 git clone https://github.com/ElanYoung/vite-vue2-js-starter-template
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,9 @@
 如果您更喜欢使用更干净的 git 历史记录手动执行此操作
 
 ```bash
+# [可选] 如果您使用的是 windows 系统，需要关闭换行符自动转换
+git config --global core.autocrlf input
+
 # 克隆
 git clone https://github.com/ElanYoung/vite-vue2-js-starter-template
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -163,7 +163,7 @@ module.exports = {
     {
       files: ['*.less', '**/*.less'],
       customSyntax: 'postcss-less',
-      extends: ['stylelint-config-standard'],
+      extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
     },
   ],
 };


### PR DESCRIPTION
本项目 prettier 使用的是 lf 换行符，windows 的 git 在克隆时，默认会将 换行符 转换为 rclf，因此在克隆项目前应该关闭自动转换的功能。